### PR TITLE
Parse keypress callback function

### DIFF
--- a/src/keypress.js
+++ b/src/keypress.js
@@ -15,7 +15,11 @@ factory('mousetrapHelper', ['$parse', function keypress($parse){
     params = scope.$eval(attrs['mousetrap'+capitaliseFirstLetter(mode)] || '{}');
     for (var binding in params) {
       (function(binding) {
-        Mousetrap.bind(binding, function(e, combo){ return scope.$apply(params[binding](e, combo)); }, mode);
+        Mousetrap.bind(binding, function(e, combo){
+          return scope.$apply(function() {
+            $parse(params[binding])(e, combo);
+          }); 
+        }, mode);
       })(binding);
     }
   };


### PR DESCRIPTION
This let us define keyboard shortcuts exactly as in the UI-Utils docs : mousetrap-keyup="{'right': 'goNext()', 'left': 'goPrev()'}"
